### PR TITLE
catch pybel import exception, throw warning

### DIFF
--- a/rubicon/testset/parse_mol.py
+++ b/rubicon/testset/parse_mol.py
@@ -10,9 +10,6 @@ try:
     import pybel as pb
 except Exception as ex:
     print "WARNING: Error importing pybel, setting pb to None!"
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(
-	exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
     pb = None
 
 from pymatgen import Element, Molecule


### PR DESCRIPTION
@xhqu1981 
bugfix allows `lpad` to work whether pybel can be imported successfully or not.
