### PR TITLE
Fix a standalone QChem script bug

### DIFF
--- a/rubicon/firetasks/qchem/qchem_task.py
+++ b/rubicon/firetasks/qchem/qchem_task.py
@@ -179,7 +179,7 @@ class QChemTask(FireTaskBase, FWSerializable):
         job = QchemJob(qc_exe, input_file=input_file, output_file=output_file,
                        qclog_file=qclog_file, alt_cmd=alt_cmd, gzipped=gzipped,
                        total_physical_memory=total_physical_memory)
-        handler = QChemErrorHandler(qchem_job=job,
+        handler = QChemErrorHandler(qchem_job=job, output_file=output_file,
                                     scf_max_cycles=scf_max_cycles,
                                     geom_max_cycles=geom_max_cycles)
         c = Custodian(handlers=[handler], jobs=[job], max_errors=50)


### PR DESCRIPTION
also pass output filename to QChemErrorHandler to support output filename other than "mol.qcout"